### PR TITLE
Revised README demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The source RMarkdown code for the website is in the [website folder](https://git
 
 To interactively run of the demo code, following a [TCIU package installation](https://github.com/SOCR/TCIU/tree/master/package/TCIU), use the following command in the R console/shell:
 ```{r}
+library(TCIU)
 demo(fmri_demo_func, package="TCIU")
 ```
 


### PR DESCRIPTION
The following error occurs when running the line as written without first loading the installed TCIU package:

> # load 3d nifti data of the mask saved in the package
> dim(mask)
Error in eval(ei, envir) : object 'mask' not found

Adding the line “library(TCIU)” to load the library prior to running the demo command resolves the encountered error and allows the demo to run successfully. While this may be obvious to many experienced with R, incoming R novices will not know how to resolve the errors produced and might assume that there is some error in the library.